### PR TITLE
Hide add new button and show message if no parents exist

### DIFF
--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -154,6 +154,8 @@ class CatalogPageExtension extends DataExtension
      */
     public function canCreate($member)
     {
-        return $this->getCatalogParents()->count() > 0;
+        return $this->getCatalogParents()->count() === 0
+            ? false
+            : null;
     }
 }

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -146,4 +146,14 @@ class CatalogPageExtension extends DataExtension
             return $sortColumn ?: 'Sort';
         }
     }
+
+    /**
+     * Prevent object creation if no parents exist.
+     * @param \SilverStripe\Security\Member|null $member
+     * @return bool
+     */
+    public function canCreate($member)
+    {
+        return $this->getCatalogParents()->count() > 0;
+    }
 }

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -104,7 +104,6 @@ abstract class CatalogPageAdmin extends ModelAdmin
         )->setHTMLID('Form_EditForm');
 
         if ($model->getCatalogParents()->count() === 0) {
-            $fieldConfig->removeComponentsByType(GridFieldAddNewButton::class);
             $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
         }
 

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -10,12 +10,15 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Requirements;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
@@ -93,12 +96,61 @@ abstract class CatalogPageAdmin extends ModelAdmin
             $fieldConfig->addComponent(new GridFieldOrderableRows($sortField));
         }
 
-        return Form::create(
+        $form = Form::create(
             $this,
             'EditForm',
             new FieldList($listField),
             new FieldList()
         )->setHTMLID('Form_EditForm');
+
+        if ($model->getCatalogParents()->count() === 0) {
+            $fieldConfig->removeComponentsByType(GridFieldAddNewButton::class);
+            $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
+        }
+
+        return $form;
+    }
+
+    /**
+     * @param \SilverStripe\ORM\DataObject|CatalogPageExtension $model
+     * @return string
+     */
+    protected function getMissingParentsMessage(DataObject $model)
+    {
+        return _t(self::class . '.PARENT_REQUIRED',
+            'You must create a {parent_class_list} before you can create a {model_name}.', [
+                'parent_class_list' => $this->getParentClassesForMessage($model->getParentClasses()),
+                'model_name'        => $model->i18n_singular_name(),
+            ]);
+    }
+
+    /**
+     * @param string[] $classes
+     * @return string
+     */
+    protected function getParentClassesForMessage(array $classes)
+    {
+        $parentNames = [];
+        foreach ($classes as $parentClass) {
+            if ($parentClass === $this->modelClass) {
+                continue;
+            }
+
+            /** @var DataObject $parent */
+            $parent = singleton($parentClass);
+            $parentNames[] = $parent->i18n_singular_name();
+        }
+
+        if (count($parentNames) === 1) {
+            return $parentNames[0];
+        }
+
+        if (count($parentNames) === 2) {
+            return "{$parentNames[0]} or {$parentNames[1]}";
+        }
+
+        $last = array_pop($parentNames);
+        return implode(', ', $parentNames) . " or {$last}";
     }
 
     /**


### PR DESCRIPTION
Currently, the package throws an exception when the add new button is clicked and no parent page candidate exists. This causes a 500 error and shows an error page to the user that gives them no information on how to resolve the issue.

This PR hides the `add new` button and shows a warning level message to the user advising them the object types they could create to have a valid parent page.

An example of the message / hidden add button component:

<img width="1147" alt="screen shot 2018-07-05 at 6 19 40 pm" src="https://user-images.githubusercontent.com/10136407/42305673-1fda39d2-8080-11e8-8876-9cbf97565006.png">
