### PR TITLE
Fix auto live sort

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,3 +10,7 @@ SilverStripe\SiteConfig\SiteConfig:
   required_permission:
     - SITETREE_VIEW_ALL
     - SITETREE_EDIT_ALL
+
+Symbiote\GridFieldExtensions\GridFieldOrderableRows:
+  extensions:
+    - LittleGiant\CatalogManager\Extensions\AutoPublishSortExtension

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "silverstripe/cms": "^4.0",
-        "symbiote/silverstripe-gridfieldextensions": "^3.0"
+        "symbiote/silverstripe-gridfieldextensions": "^3.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extensions/AutoPublishSortExtension.php
+++ b/src/Extensions/AutoPublishSortExtension.php
@@ -35,7 +35,7 @@ class AutoPublishSortExtension extends Extension
         }
 
         foreach ($sortedIDs as $sortValue => $itemID) {
-            DB::query("UPDATE \"{$tableName}_Live\" SET \"{$sortField}\"={$sortValue} WHERE \"ID\"={$itemID}");
+            DB::prepared_query('UPDATE "' . $tableName . '_Live" SET "' . $sortField . '"=? WHERE "ID"=?', [$sortValue, $itemID]);
         }
     }
 }

--- a/src/Extensions/AutoPublishSortExtension.php
+++ b/src/Extensions/AutoPublishSortExtension.php
@@ -2,6 +2,7 @@
 
 namespace LittleGiant\CatalogManager\Extensions;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -22,7 +23,7 @@ class AutoPublishSortExtension extends Extension
     public function onAfterReorderItems(SS_List &$list, array $values, array $sortedIDs)
     {
         $modelClass = $list->dataClass();
-        /** @var \LittleGiant\CatalogManager\Extensions\CatalogPageExtension|\SilverStripe\CMS\Model\SiteTree $model */
+        /** @var CatalogPageExtension|SiteTree $model */
         $model = singleton($modelClass);
         if (!$model::config()->get('automatic_live_sort')) {
             return;

--- a/src/Extensions/AutoPublishSortExtension.php
+++ b/src/Extensions/AutoPublishSortExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LittleGiant\CatalogManager\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\SS_List;
+
+/**
+ * Class AutoPublishSortExtension
+ * @package LittleGiant\CatalogManager\Extensions
+ */
+class AutoPublishSortExtension extends Extension
+{
+    /**
+     * @see \Symbiote\GridFieldExtensions\GridFieldOrderableRows::reorderItems()
+     * @param \SilverStripe\ORM\ArrayList|\SilverStripe\ORM\DataList $list
+     * @param array $values [listItemID => currentSortValue];
+     * @param array $sortedIDs [newSortValue => listItemID]
+     */
+    public function onAfterReorderItems(SS_List &$list, array $values, array $sortedIDs)
+    {
+        $modelClass = $list->dataClass();
+        /** @var \LittleGiant\CatalogManager\Extensions\CatalogPageExtension|\SilverStripe\CMS\Model\SiteTree $model */
+        $model = singleton($modelClass);
+        if (!$model::config()->get('automatic_live_sort')) {
+            return;
+        }
+
+        $sortField = CatalogPageExtension::getClassSortFieldName($modelClass);
+        $tableName = DataObject::getSchema()->tableForField($modelClass, $sortField);
+        if ($tableName === null) {
+            throw new \Exception("Sort field {$sortField} could not be found in table hierarchy for {$modelClass}.");
+        }
+
+        foreach ($sortedIDs as $sortValue => $itemID) {
+            DB::query("UPDATE \"{$tableName}_Live\" SET \"{$sortField}\"={$sortValue} WHERE \"ID\"={$itemID}");
+        }
+    }
+}

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -22,7 +22,6 @@ class CatalogPageExtension extends DataExtension
     const CONFIG_SETTINGS_WITH_DEFAULTS = [
         'parent_classes',
         'can_duplicate',
-        'sort_column',
         'automatic_live_sort',
     ];
 
@@ -37,14 +36,6 @@ class CatalogPageExtension extends DataExtension
      * @var bool
      */
     private static $can_duplicate = true;
-
-    /**
-     * Name of the sorting column. SiteTree has a column named "Sort", we use this as default.
-     *
-     * @config
-     * @var string
-     */
-    private static $sort_column = 'Sort';
 
     /**
      * @config
@@ -157,7 +148,7 @@ class CatalogPageExtension extends DataExtension
 
         return $sortColumn === false
             ? null
-            : ($sortColumn ?: Config::forClass(static::class)->get('sort_column'));
+            : ($sortColumn ?: 'Sort');
     }
 
     /**

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -4,6 +4,7 @@ namespace LittleGiant\CatalogManager\Extensions;
 
 use Exception;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
@@ -138,13 +139,25 @@ class CatalogPageExtension extends DataExtension
      */
     public function getSortFieldName()
     {
-        $sortColumn = $this->owner->config()->get('sort_column');
+        return static::getClassSortFieldName($this->owner);
+    }
 
-        if ($sortColumn === false) {
-            return null;
-        } else {
-            return $sortColumn ?: 'Sort';
-        }
+    /**
+     * Gets the field name for a class's sort column. As CatalogPageExtension is applied to subclasses of SiteTree,
+     * 'Sort' is default.
+     * Can be overwritten using $sort_column config on extended class.
+     * Set $sort_column config to false to disable sorting in the gridfield
+     *
+     * @param string|object $class
+     * @return null|string
+     */
+    public static function getClassSortFieldName($class)
+    {
+        $sortColumn = Config::forClass($class)->get('sort_column');
+
+        return $sortColumn === false
+            ? null
+            : ($sortColumn ?: Config::forClass(static::class)->get('sort_column'));
     }
 
     /**

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -150,30 +150,4 @@ abstract class CatalogPageAdmin extends ModelAdmin
         $last = array_pop($parentNames);
         return implode(', ', $parentNames) . " or {$last}";
     }
-
-    /**
-     * Hook to update sort column on live versions of items after a sort has occured.
-     * @param $items
-     */
-    public function onAfterGridFieldRowSort($items)
-    {
-        /** @var \LittleGiant\CatalogManager\Extensions\CatalogPageExtension|\SilverStripe\CMS\Model\SiteTree $model */
-        $model = singleton($this->modelClass);
-        if (!$model::config()->get('automatic_live_sort')) {
-            return;
-        }
-
-        // if the sort is the default, then we should update SiteTree. If its a custom sort, update the model.
-        $sortField = $model->getSortFieldName();
-        $tableName = DataObjectSchema::singleton()->tableForField($this->modelClass, $sortField);
-        if ($tableName === null) {
-            throw new \Exception("Sort field {$sortField} could not be found in table hierarchy for {$this->modelClass}.");
-        }
-
-        foreach ($items as $item) {
-            if ($item instanceof $this->modelClass) {
-                DB::query("UPDATE \"{$tableName}_Live\" SET \"{$model->getSortFieldname()}\"=\"{$item->{$sortField}}\" WHERE \"ID\"=\"{$item->ID}\"");
-            }
-        }
-    }
 }

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -10,7 +10,6 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;


### PR DESCRIPTION
`undefinedoffset/sortablegridfield` was replaced with `GridFieldOrderableRows` from `symbiote/gridfieldextensions`. This exposes an extension point rather than calling an event on the `ModelAdmin`. This PR modifies the package to replacing the old event code with an extension for automatic live sorting.