### PR TITLE
Fix root catalog page - empty parent class array

### DIFF
--- a/src/Extensions/AutoPublishSortExtension.php
+++ b/src/Extensions/AutoPublishSortExtension.php
@@ -3,6 +3,7 @@
 namespace LittleGiant\CatalogManager\Extensions;
 
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -23,9 +24,7 @@ class AutoPublishSortExtension extends Extension
     public function onAfterReorderItems(SS_List &$list, array $values, array $sortedIDs)
     {
         $modelClass = $list->dataClass();
-        /** @var CatalogPageExtension|SiteTree $model */
-        $model = singleton($modelClass);
-        if (!$model::config()->get('automatic_live_sort')) {
+        if (!Config::forClass($modelClass)->get('automatic_live_sort')) {
             return;
         }
 

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -160,7 +160,7 @@ class CatalogPageExtension extends DataExtension
     public function canCreate($member)
     {
         $parentCandidates = $this->getCatalogParents();
-        return $parentCandidates !== null && $parentCandidates->count() === 0
+        return $parentCandidates === null || $parentCandidates->count() === 0
             ? false
             : null;
     }

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -73,6 +73,7 @@ class CatalogPageExtension extends DataExtension
         $pages = $this->getCatalogParents();
 
         if ($pages === null) {
+            // Root page
             return;
         }
 
@@ -113,7 +114,7 @@ class CatalogPageExtension extends DataExtension
         $parentClasses = $this->getParentClasses();
         $parents = null;
 
-        if ($parentClasses !== null) {
+        if (!empty($parentClasses)) {
             $parents = SiteTree::get()->filter('ClassName', $parentClasses);
         }
         $this->owner->extend('updateCatalogParents', $parents);
@@ -158,7 +159,8 @@ class CatalogPageExtension extends DataExtension
      */
     public function canCreate($member)
     {
-        return $this->getCatalogParents()->count() === 0
+        $parentCandidates = $this->getCatalogParents();
+        return $parentCandidates !== null && $parentCandidates->count() === 0
             ? false
             : null;
     }

--- a/src/Extensions/CatalogPageExtension.php
+++ b/src/Extensions/CatalogPageExtension.php
@@ -69,23 +69,20 @@ class CatalogPageExtension extends DataExtension
      */
     public function updateCMSFields(FieldList $fields)
     {
-        $parentClass = $this->getParentClasses();
-        $pages = $this->getCatalogParents();
-
-        if ($pages === null) {
+        $parentPages = $this->getCatalogParents();
+        if ($parentPages === null) {
             // Root page
             return;
         }
 
-        $parentCount = $pages->count();
-
+        $parentCount = count($parentPages);
         if ($parentCount === 0) {
-            throw new Exception('You must create a parent page with one of these classes: ' . implode(', ', $parentClass));
+            throw new Exception('You must create a parent page with one of these classes: ' . implode(', ', $this->getParentClasses()));
         } elseif ($parentCount === 1) {
-            $field = HiddenField::create('ParentID', 'ParentID', $pages->first()->ID);
+            $field = HiddenField::create('ParentID', 'ParentID', $parentPages->first()->ID);
         } else {
-            $defaultParentID = $this->owner->ParentID ?: $pages->first()->ID;
-            $field = DropdownField::create('ParentID', _t(__CLASS__ . '.PARENTPAGE', 'Parent Page'), $pages->map(), $defaultParentID);
+            $defaultParentID = $this->owner->ParentID ?: $parentPages->first()->ID;
+            $field = DropdownField::create('ParentID', _t(__CLASS__ . '.PARENTPAGE', 'Parent Page'), $parentPages->map(), $defaultParentID);
         }
 
         $fields->addFieldToTab('Root.Main', $field);
@@ -159,8 +156,7 @@ class CatalogPageExtension extends DataExtension
      */
     public function canCreate($member)
     {
-        $parentCandidates = $this->getCatalogParents();
-        return $parentCandidates === null || $parentCandidates->count() === 0
+        return count($this->getCatalogParents()) === 0
             ? false
             : null;
     }

--- a/src/Forms/CatalogPageGridFieldItemRequest.php
+++ b/src/Forms/CatalogPageGridFieldItemRequest.php
@@ -25,16 +25,14 @@ class CatalogPageGridFieldItemRequest extends VersionedGridFieldItemRequest
     {
         $editForm = parent::ItemEditForm();
 
-        // Already has parent
-        if ($this->record->ParentID) return $editForm;
+        if ($this->record->ParentID) {
+            // Already has parent
+            return $editForm;
+        }
 
         // Set a default parent id for the record, even if it will change
         $parents = $this->record->getCatalogParents();
-
-        if ($parents === null) return $editForm; // Root page
-
-        $first = $parents->first();
-        if ($first !== null) {
+        if ($parents !== null && $first = $parents->first()) {
             $this->record->ParentID = $first->ID;
         }
 

--- a/src/Forms/CatalogPageGridFieldItemRequest.php
+++ b/src/Forms/CatalogPageGridFieldItemRequest.php
@@ -23,20 +23,16 @@ class CatalogPageGridFieldItemRequest extends VersionedGridFieldItemRequest
      */
     public function ItemEditForm()
     {
-        $editForm = parent::ItemEditForm();
-
-        if ($this->record->ParentID) {
-            // Already has parent
-            return $editForm;
+        if (!empty($this->record) && !$this->record->ParentID) {
+            // Set a default parent id for the record, even if it will change
+            $parents = $this->record->getCatalogParents();
+            $first = $parents !== null ? $parents->first() : null;
+            if ($first !== null) {
+                $this->record->ParentID = $first->ID;
+            }
         }
 
-        // Set a default parent id for the record, even if it will change
-        $parents = $this->record->getCatalogParents();
-        if ($parents !== null && $first = $parents->first()) {
-            $this->record->ParentID = $first->ID;
-        }
-
-        return $editForm;
+        return parent::ItemEditForm();
     }
 
     /**

--- a/src/Forms/CatalogPageGridFieldItemRequest.php
+++ b/src/Forms/CatalogPageGridFieldItemRequest.php
@@ -23,15 +23,22 @@ class CatalogPageGridFieldItemRequest extends VersionedGridFieldItemRequest
      */
     public function ItemEditForm()
     {
-        if (!$this->record->ParentID) {
-            // set a parent id for the record, even if it will change
-            $parents = $this->record->getCatalogParents();
-            if ($parents !== null && $parents->exists()) {
-                $this->record->ParentID = $parents->first()->ID;
-            }
+        $editForm = parent::ItemEditForm();
+
+        // Already has parent
+        if ($this->record->ParentID) return $editForm;
+
+        // Set a default parent id for the record, even if it will change
+        $parents = $this->record->getCatalogParents();
+
+        if ($parents === null) return $editForm; // Root page
+
+        $first = $parents->first();
+        if ($first !== null) {
+            $this->record->ParentID = $first->ID;
         }
 
-        return parent::ItemEditForm();
+        return $editForm;
     }
 
     /**

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -102,8 +102,7 @@ abstract class CatalogPageAdmin extends ModelAdmin
             new FieldList()
         )->setHTMLID('Form_EditForm');
 
-        $parentCandidates = $model->getCatalogParents();
-        if ($parentCandidates === null || $parentCandidates->count() === 0) {
+        if (count($model->getCatalogParents()) === 0) {
             $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
         }
 

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -102,7 +102,8 @@ abstract class CatalogPageAdmin extends ModelAdmin
             new FieldList()
         )->setHTMLID('Form_EditForm');
 
-        if ($model->getCatalogParents()->count() === 0) {
+        $parentCandidates = $model->getCatalogParents();
+        if ($parentCandidates !== null && $parentCandidates->count() === 0) {
             $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
         }
 

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -103,7 +103,7 @@ abstract class CatalogPageAdmin extends ModelAdmin
         )->setHTMLID('Form_EditForm');
 
         $parentCandidates = $model->getCatalogParents();
-        if ($parentCandidates !== null && $parentCandidates->count() === 0) {
+        if ($parentCandidates === null || $parentCandidates->count() === 0) {
             $form->setMessage($this->getMissingParentsMessage($model), ValidationResult::TYPE_WARNING);
         }
 

--- a/src/ModelAdmin/CatalogPageAdmin.php
+++ b/src/ModelAdmin/CatalogPageAdmin.php
@@ -47,7 +47,7 @@ abstract class CatalogPageAdmin extends ModelAdmin
         $model = singleton($this->modelClass);
 
         if ($model->has_extension(CatalogPageExtension::class)) {
-            $form = $this->getCatalogEditForm($id, $fields, $model);
+            $form = $this->getCatalogEditForm($model, $id, $fields);
         } elseif (method_exists($model, 'getAdminListField')) {
             $form = Form::create(
                 $this,
@@ -64,12 +64,12 @@ abstract class CatalogPageAdmin extends ModelAdmin
     }
 
     /**
-     * @param null $id
-     * @param null $fields
      * @param \SilverStripe\CMS\Model\SiteTree|\LittleGiant\CatalogManager\Extensions\CatalogPageExtension $model
+     * @param null|string $id
+     * @param null|string $fields
      * @return \SilverStripe\Forms\Form
      */
-    protected function getCatalogEditForm($id = null, $fields = null, $model)
+    protected function getCatalogEditForm($model, $id = null, $fields = null)
     {
         $originalStage = Versioned::get_stage();
         Versioned::set_stage(Versioned::DRAFT);


### PR DESCRIPTION
Empty parent class array tries to filter by empty value and cause the ORM to throw an exception. This PR adds an `empty()` check rather than a null check to resolve this.

Affected line: `$parents = SiteTree::get()->filter('ClassName', $parentClasses);`